### PR TITLE
Update auth action to always expect an ECL enrolment

### DIFF
--- a/app/uk/gov/hmrc/economiccrimelevyreturns/controllers/ReturnSubmissionController.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyreturns/controllers/ReturnSubmissionController.scala
@@ -43,9 +43,7 @@ class ReturnSubmissionController @Inject() (
       case Some(eclReturn) =>
         returnValidationService.validateReturn(eclReturn) match {
           case Valid(eclReturnDetails) =>
-            val eclRegistrationReference = request.eclRegistrationReference
-              .getOrElse(throw new IllegalStateException("ECL registration reference not found in request"))
-            returnService.submitEclReturn(eclRegistrationReference, eclReturnDetails).map { response =>
+            returnService.submitEclReturn(request.eclRegistrationReference, eclReturnDetails).map { response =>
               Ok(Json.toJson(response))
             }
           case Invalid(e)              =>

--- a/app/uk/gov/hmrc/economiccrimelevyreturns/controllers/actions/AuthorisedAction.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyreturns/controllers/actions/AuthorisedAction.scala
@@ -22,7 +22,7 @@ import play.api.libs.json.Json
 import play.api.mvc.Results.Unauthorized
 import play.api.mvc._
 import uk.gov.hmrc.auth.core._
-import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals.{allEnrolments, internalId}
+import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals.{authorisedEnrolments, internalId}
 import uk.gov.hmrc.auth.core.retrieve.~
 import uk.gov.hmrc.economiccrimelevyreturns.models.eacd.EclEnrolment
 import uk.gov.hmrc.economiccrimelevyreturns.models.requests.AuthorisedRequest
@@ -45,14 +45,18 @@ class BaseAuthorisedAction @Inject() (
     with AuthorisedFunctions {
 
   override def invokeBlock[A](request: Request[A], block: AuthorisedRequest[A] => Future[Result]): Future[Result] =
-    authorised().retrieve(internalId and allEnrolments) { case optInternalId ~ enrolments =>
-      val internalId                  = optInternalId.getOrElseFail("Unable to retrieve internalId")
-      val optEclRegistrationReference =
-        enrolments
-          .getEnrolment(EclEnrolment.ServiceName)
-          .flatMap(_.getIdentifier(EclEnrolment.IdentifierKey))
-          .map(identifier => identifier.value)
-      block(AuthorisedRequest(request, internalId, optEclRegistrationReference))
+    authorised(Enrolment(EclEnrolment.ServiceName)).retrieve(internalId and authorisedEnrolments) {
+      case optInternalId ~ enrolments =>
+        val internalId               = optInternalId.getOrElseFail("Unable to retrieve internalId")
+        val eclRegistrationReference =
+          enrolments
+            .getEnrolment(EclEnrolment.ServiceName)
+            .flatMap(_.getIdentifier(EclEnrolment.IdentifierKey))
+            .getOrElseFail(
+              s"Unable to retrieve enrolment with key ${EclEnrolment.ServiceName} and identifier ${EclEnrolment.IdentifierKey}"
+            )
+            .value
+        block(AuthorisedRequest(request, internalId, eclRegistrationReference))
     }(hc(request), executionContext) recover { case e: AuthorisationException =>
       Unauthorized(
         Json.toJson(

--- a/app/uk/gov/hmrc/economiccrimelevyreturns/models/requests/AuthorisedRequest.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyreturns/models/requests/AuthorisedRequest.scala
@@ -18,5 +18,5 @@ package uk.gov.hmrc.economiccrimelevyreturns.models.requests
 
 import play.api.mvc.{Request, WrappedRequest}
 
-case class AuthorisedRequest[A](request: Request[A], internalId: String, eclRegistrationReference: Option[String])
+case class AuthorisedRequest[A](request: Request[A], internalId: String, eclRegistrationReference: String)
     extends WrappedRequest[A](request)

--- a/it/uk/gov/hmrc/economiccrimelevyreturns/base/AuthStubs.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyreturns/base/AuthStubs.scala
@@ -15,7 +15,7 @@ trait AuthStubs { self: WireMockStubs =>
             s"""
                |{
                |  "authorise": [],
-               |  "retrieve": [ "internalId", "allEnrolments" ]
+               |  "retrieve": [ "internalId", "authorisedEnrolments" ]
                |}
          """.stripMargin,
             true,
@@ -28,7 +28,7 @@ trait AuthStubs { self: WireMockStubs =>
           s"""
              |{
              |  "internalId": "$testInternalId",
-             |  "allEnrolments": [{
+             |  "authorisedEnrolments": [{
              |    "key":"${EclEnrolment.ServiceName}",
              |    "identifiers": [{ "key":"${EclEnrolment.IdentifierKey}", "value": "$testEclRegistrationReference" }],
              |    "state": "activated"

--- a/test/uk/gov/hmrc/economiccrimelevyreturns/controllers/actions/AuthorisedActionSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyreturns/controllers/actions/AuthorisedActionSpec.scala
@@ -24,8 +24,9 @@ import uk.gov.hmrc.auth.core._
 import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals
 import uk.gov.hmrc.auth.core.retrieve.{Retrieval, ~}
 import uk.gov.hmrc.auth.core.syntax.retrieved.authSyntaxForRetrieved
-import uk.gov.hmrc.economiccrimelevyreturns.EnrolmentsWithEcl
+import uk.gov.hmrc.economiccrimelevyreturns.{EnrolmentsWithEcl, EnrolmentsWithoutEcl}
 import uk.gov.hmrc.economiccrimelevyreturns.base.SpecBase
+import uk.gov.hmrc.economiccrimelevyreturns.models.eacd.EclEnrolment
 
 import scala.concurrent.Future
 
@@ -42,7 +43,7 @@ class AuthorisedActionSpec extends SpecBase {
   }
 
   val expectedRetrievals: Retrieval[Option[String] ~ Enrolments] =
-    Retrievals.internalId and Retrievals.allEnrolments
+    Retrievals.internalId and Retrievals.authorisedEnrolments
 
   "invokeBlock" should {
     "execute the block and return the result if authorised" in forAll {
@@ -87,6 +88,18 @@ class AuthorisedActionSpec extends SpecBase {
       }
 
       result.getMessage shouldBe "Unable to retrieve internalId"
+    }
+
+    "throw an IllegalStateException if there is no ECL enrolment in the set of authorised enrolments" in forAll {
+      (internalId: String, enrolmentsWithoutEcl: EnrolmentsWithoutEcl) =>
+        when(mockAuthConnector.authorise(any(), ArgumentMatchers.eq(expectedRetrievals))(any(), any()))
+          .thenReturn(Future(Some(internalId) and enrolmentsWithoutEcl.enrolments))
+
+        val result = intercept[IllegalStateException] {
+          await(authorisedAction.invokeBlock(fakeRequest, testAction))
+        }
+
+        result.getMessage shouldBe s"Unable to retrieve enrolment with key ${EclEnrolment.ServiceName} and identifier ${EclEnrolment.IdentifierKey}"
     }
   }
 

--- a/test/uk/gov/hmrc/economiccrimelevyreturns/controllers/actions/FakeAuthorisedAction.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyreturns/controllers/actions/FakeAuthorisedAction.scala
@@ -27,7 +27,7 @@ class FakeAuthorisedAction @Inject() (bodyParsers: PlayBodyParsers) extends Auth
   override def parser: BodyParser[AnyContent] = bodyParsers.defaultBodyParser
 
   override def invokeBlock[A](request: Request[A], block: AuthorisedRequest[A] => Future[Result]): Future[Result] =
-    block(AuthorisedRequest(request, "id", Some("test-ecl-registration-reference")))
+    block(AuthorisedRequest(request, "id", "test-ecl-registration-reference"))
 
   override protected def executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
 


### PR DESCRIPTION
This is now valid as the calculate API has been moved to economic-crime-levy-calculator, therefore calls to this service must be authorised with an ECL enrolment.