### PR TITLE
ECL-496: Currency inputs validation

### DIFF
--- a/app/uk/gov/hmrc/economiccrimelevyreturns/models/CalculatedLiability.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyreturns/models/CalculatedLiability.scala
@@ -43,7 +43,7 @@ object Band {
   }
 }
 
-final case class EclAmount(amount: BigDecimal, apportioned: Boolean)
+final case class EclAmount(amount: Double, apportioned: Boolean)
 
 object EclAmount {
   implicit val format: OFormat[EclAmount] = Json.format[EclAmount]

--- a/app/uk/gov/hmrc/economiccrimelevyreturns/models/EclReturn.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyreturns/models/EclReturn.scala
@@ -48,7 +48,7 @@ final case class EclReturn(
   internalId: String,
   relevantAp12Months: Option[Boolean],
   relevantApLength: Option[Int],
-  relevantApRevenue: Option[Long],
+  relevantApRevenue: Option[Double],
   carriedOutAmlRegulatedActivityForFullFy: Option[Boolean],
   amlRegulatedActivityLength: Option[Int],
   calculatedLiability: Option[CalculatedLiability],

--- a/app/uk/gov/hmrc/economiccrimelevyreturns/models/integrationframework/EclReturnSubmission.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyreturns/models/integrationframework/EclReturnSubmission.scala
@@ -21,8 +21,8 @@ import uk.gov.hmrc.economiccrimelevyreturns.models.Band
 
 final case class EclReturnDetails(
   revenueBand: Band,
-  amountOfEclDutyLiable: BigDecimal,
-  accountingPeriodRevenue: BigDecimal,
+  amountOfEclDutyLiable: Double,
+  accountingPeriodRevenue: Double,
   accountingPeriodLength: Int,
   numberOfDaysRegulatedActivityTookPlace: Option[Int],
   returnDate: String

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ lazy val root = (project in file("."))
   .configs(IntegrationTest)
   .settings(inConfig(IntegrationTest)(itSettings): _*)
   .settings(majorVersion := 0)
-  .settings(ThisBuild / useSuperShell := false)
+  .settings(inThisBuild(buildSettings))
   .settings(scoverageSettings: _*)
   .settings(scalaCompilerOptions: _*)
   .settings(
@@ -49,6 +49,11 @@ lazy val itSettings: Seq[Def.Setting[_]] = Defaults.itSettings ++ Seq(
   parallelExecution := false,
   fork := true,
   scalafmtOnCompile := true
+)
+
+lazy val buildSettings = Def.settings(
+  scalafmtOnCompile := true,
+  useSuperShell := false
 )
 
 val excludedScoveragePackages: Seq[String] = Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ lazy val root = (project in file("."))
   .configs(IntegrationTest)
   .settings(inConfig(IntegrationTest)(itSettings): _*)
   .settings(majorVersion := 0)
-  .settings(inThisBuild(buildSettings))
+  .settings(ThisBuild / useSuperShell := false)
   .settings(scoverageSettings: _*)
   .settings(scalaCompilerOptions: _*)
   .settings(
@@ -49,11 +49,6 @@ lazy val itSettings: Seq[Def.Setting[_]] = Defaults.itSettings ++ Seq(
   parallelExecution := false,
   fork := true,
   scalafmtOnCompile := true
-)
-
-lazy val buildSettings = Def.settings(
-  scalafmtOnCompile := true,
-  useSuperShell := false
 )
 
 val excludedScoveragePackages: Seq[String] = Seq(

--- a/it/uk/gov/hmrc/economiccrimelevyreturns/base/AuthStubs.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyreturns/base/AuthStubs.scala
@@ -12,8 +12,7 @@ trait AuthStubs { self: WireMockStubs =>
       post(urlEqualTo("/auth/authorise")),
       aResponse()
         .withStatus(OK)
-        .withBody(
-          s"""
+        .withBody(s"""
              |{
              |  "internalId": "$testInternalId",
              |  "authorisedEnrolments": [{

--- a/it/uk/gov/hmrc/economiccrimelevyreturns/base/ISpecBase.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyreturns/base/ISpecBase.scala
@@ -57,8 +57,7 @@ abstract class ISpecBase
     with EclTestData
     with Generators {
 
-
-  implicit lazy val arbString: Arbitrary[String]    = Arbitrary(Gen.alphaNumStr.retryUntil(_.nonEmpty))
+  implicit lazy val arbString: Arbitrary[String] = Arbitrary(Gen.alphaNumStr.retryUntil(_.nonEmpty))
 
   implicit lazy val system: ActorSystem        = ActorSystem()
   implicit lazy val materializer: Materializer = Materializer(system)
@@ -72,10 +71,10 @@ abstract class ISpecBase
 
   val additionalAppConfig: Map[String, Any] = Map(
     "create-internal-auth-token-on-start" -> false,
-    "metrics.enabled"              -> false,
-    "auditing.enabled"             -> false,
-    "http-verbs.retries.intervals" -> List("1ms", "1ms", "1ms"),
-    "application.router"           -> "testOnlyDoNotUseInAppConf.Routes"
+    "metrics.enabled"                     -> false,
+    "auditing.enabled"                    -> false,
+    "http-verbs.retries.intervals"        -> List("1ms", "1ms", "1ms"),
+    "application.router"                  -> "testOnlyDoNotUseInAppConf.Routes"
   ) ++ setWireMockPort(
     "auth",
     "integration-framework",

--- a/it/uk/gov/hmrc/economiccrimelevyreturns/base/IntegrationFrameworkStubs.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyreturns/base/IntegrationFrameworkStubs.scala
@@ -9,9 +9,9 @@ import uk.gov.hmrc.economiccrimelevyreturns.models.integrationframework.{EclRetu
 trait IntegrationFrameworkStubs { self: WireMockStubs =>
 
   def stubSubmitEclReturn(
-                           eclRegistrationReference: String,
-                           eclReturnSubmission: EclReturnSubmission,
-                           eclReturnResponse: SubmitEclReturnResponse
+    eclRegistrationReference: String,
+    eclReturnSubmission: EclReturnSubmission,
+    eclReturnResponse: SubmitEclReturnResponse
   ): StubMapping =
     stub(
       post(urlEqualTo(s"/economic-crime-levy/return/$eclRegistrationReference"))

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object AppDependencies {
 
-  private val hmrcBootstrapVersion = "7.19.0"
+  private val hmrcBootstrapVersion = "7.22.0"
   private val hmrcMongoVersion     = "1.3.0"
   private val openHtmlToPdfVersion = "1.0.10"
 
@@ -11,18 +11,17 @@ object AppDependencies {
     "uk.gov.hmrc"       %% "bootstrap-backend-play-28" % hmrcBootstrapVersion,
     "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-28"        % hmrcMongoVersion,
     "com.openhtmltopdf"  % "openhtmltopdf-pdfbox"      % openHtmlToPdfVersion,
-    "org.typelevel"     %% "cats-core"                 % "2.9.0",
+    "org.typelevel"     %% "cats-core"                 % "2.10.0",
     "io.circe"          %% "circe-json-schema"         % "0.2.0",
     "uk.gov.hmrc"       %% "internal-auth-client-play-28"      % "1.6.0",
     "io.circe"          %% "circe-parser"              % "0.14.5",
-    "uk.gov.hmrc"       %% "internal-auth-client-play-28" % "1.6.0",
-    "com.beachape"      %% "enumeratum-play-json"     % "1.7.0"
+    "com.beachape"      %% "enumeratum-play-json"     % "1.7.3"
   )
 
   val test: Seq[ModuleID]    = Seq(
     "uk.gov.hmrc"          %% "bootstrap-test-play-28"   % hmrcBootstrapVersion,
     "uk.gov.hmrc.mongo"    %% "hmrc-mongo-test-play-28"  % hmrcMongoVersion,
-    "org.mockito"          %% "mockito-scala"            % "1.17.12",
+    "org.mockito"          %% "mockito-scala"            % "1.17.27",
     "org.scalatestplus"    %% "scalatestplus-scalacheck" % "3.1.0.0-RC2",
     "com.danielasfregola"  %% "random-data-generator"    % "2.9",
     "io.circe"             %% "circe-json-schema"        % "0.2.0",

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object AppDependencies {
 
-  private val hmrcBootstrapVersion = "7.22.0"
+  private val hmrcBootstrapVersion = "7.19.0"
   private val hmrcMongoVersion     = "1.3.0"
   private val openHtmlToPdfVersion = "1.0.10"
 
@@ -11,17 +11,18 @@ object AppDependencies {
     "uk.gov.hmrc"       %% "bootstrap-backend-play-28" % hmrcBootstrapVersion,
     "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-28"        % hmrcMongoVersion,
     "com.openhtmltopdf"  % "openhtmltopdf-pdfbox"      % openHtmlToPdfVersion,
-    "org.typelevel"     %% "cats-core"                 % "2.10.0",
+    "org.typelevel"     %% "cats-core"                 % "2.9.0",
     "io.circe"          %% "circe-json-schema"         % "0.2.0",
     "uk.gov.hmrc"       %% "internal-auth-client-play-28"      % "1.6.0",
     "io.circe"          %% "circe-parser"              % "0.14.5",
-    "com.beachape"      %% "enumeratum-play-json"     % "1.7.3"
+    "uk.gov.hmrc"       %% "internal-auth-client-play-28" % "1.6.0",
+    "com.beachape"      %% "enumeratum-play-json"     % "1.7.0"
   )
 
   val test: Seq[ModuleID]    = Seq(
     "uk.gov.hmrc"          %% "bootstrap-test-play-28"   % hmrcBootstrapVersion,
     "uk.gov.hmrc.mongo"    %% "hmrc-mongo-test-play-28"  % hmrcMongoVersion,
-    "org.mockito"          %% "mockito-scala"            % "1.17.27",
+    "org.mockito"          %% "mockito-scala"            % "1.17.12",
     "org.scalatestplus"    %% "scalatestplus-scalacheck" % "3.1.0.0-RC2",
     "com.danielasfregola"  %% "random-data-generator"    % "2.9",
     "io.circe"             %% "circe-json-schema"        % "0.2.0",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,9 +4,9 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy2", url("https://open.artefact
 )
 resolvers += Resolver.typesafeRepo("releases")
 
-addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"        % "3.9.0")
+addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"        % "3.14.0")
 addSbtPlugin("uk.gov.hmrc"       % "sbt-distributables"    % "2.2.0")
-addSbtPlugin("com.typesafe.play" % "sbt-plugin"            % "2.8.19")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin"            % "2.8.20")
 addSbtPlugin("org.scoverage"     % "sbt-scoverage"         % "1.9.3")
 addSbtPlugin("org.scalastyle"   %% "scalastyle-sbt-plugin" % "1.0.0")
-addSbtPlugin("org.scalameta"     % "sbt-scalafmt"          % "2.4.0")
+addSbtPlugin("org.scalameta"     % "sbt-scalafmt"          % "2.5.2")


### PR DESCRIPTION
Now allowing revenue value to be entered with to be up to 2dp, thus modifying it from a long to a double in the backend